### PR TITLE
Remove field SQL limit

### DIFF
--- a/admin/class-cpt-to-map-store-admin.php
+++ b/admin/class-cpt-to-map-store-admin.php
@@ -260,8 +260,7 @@ class Cpt_To_Map_Store_Admin {
 					ON m.post_id = p.id
 			WHERE
 				p.post_type IN ( ".$format_in." )       
-				AND Substr(meta_key, 1, 1) <> '_'
-			LIMIT  50  
+				AND Substr(meta_key, 1, 1) <> '_' 
 		";
 
 		$query_sql = $wpdb->prepare( $query_sql , $cpts );


### PR DESCRIPTION
In some cases, especially with some themes that come with a lot of plugins (esp. the page builder kind) and customization options, a lot of fields are created per post type, which leads to missing fields in the Admin UI with the current limitation to 50. So I removed it.